### PR TITLE
Playing with IPNS

### DIFF
--- a/ipfsspec/__init__.py
+++ b/ipfsspec/__init__.py
@@ -1,4 +1,4 @@
-from .core import IPFSFileSystem
+from .core import IPFSFileSystem, IPNSFileSystem
 from fsspec import register_implementation
 
 from ._version import get_versions
@@ -6,5 +6,6 @@ __version__ = get_versions()['version']
 del get_versions
 
 register_implementation(IPFSFileSystem.protocol, IPFSFileSystem)
+register_implementation(IPNSFileSystem.protocol, IPNSFileSystem)
 
-__all__ = ["__version__", "IPFSFileSystem"]
+__all__ = ["__version__", "IPFSFileSystem", "IPNSFileSystem"]


### PR DESCRIPTION
Do not merge. 

PR is mainly to provoke discussion surrounding IPNS R/W support and what would need to happen to get this repo minimally working with DVC.

My understanding is that if this had write support, it _could_ be used in DVC (even if not efficient). IPNS is one solution (although I hear DNSLink is probably better).

I'm also just playing with this to get a better feel for the fsspec code. I've mainly added doctests that demo a few ways I've tried to use the repo. 

I also added an IPNSFileSystem, because the current IPFSFileSystem does not work with ipns references. The reason for this was something I found odd. The `get` method in the Gateway hard-coded an "/ipfs/" prefix on the path. If that wasn't there, this would work with "/ipns/" prefixed addresses, although it would be cumbersome to type: `ipfs:///ipfs/<cid>` or `ipfs:///ipns/<name>` the triple `/` is not desirable.

I abstracted the entire thing to just use a `'/{self.protocol}/` prefix, and I added that to both "ls" and "info" methods of the filesystem itself for consistency with the "get" call of the gateway. Not sure exactly what the right design decisions are here. Thoughts?