### PR TITLE
don't retry if object is known to be missing

### DIFF
--- a/ipfsspec/async_ipfs.py
+++ b/ipfsspec/async_ipfs.py
@@ -202,6 +202,8 @@ class MultiGateway(AsyncIPFSGatewayBase):
                     if state.speedup(time.monotonic() - now):
                         logger.debug("%s speedup", gw)
                     return res
+                except FileNotFoundError:  # early exit if object doesn't exist
+                    raise
                 except (RequestsTooQuick, aiohttp.ClientResponseError, asyncio.TimeoutError) as e:
                     state.backoff()
                     logger.debug("%s backoff %s", gw, e)


### PR DESCRIPTION
Fixes #11

There's no point in retrying requests on a `FileNotFound` error, because this error indicates that an object is known to be absent.

**Note**: This is only possible for pathed references within a CID, where the Gateway can check for all existing parts within the CID. If an entire CID doesn't exist, there's no way to be sure that the object really doesn't exist. In this case, Gateways will still timeout (either in the client or by returning 504). 