### PR TITLE
use aiohttp-retry to try again on specific request errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "fsspec>=0.9.0",
     "requests",
     "aiohttp",
+    "aiohttp-retry",
     "multiformats",
     "dag-cbor >= 0.2.2",
     "pure-protobuf >= 2.1.0, <3",


### PR DESCRIPTION
Sometimes, especially when requesting many objects at once, timeouts occur, which (again sometimes) lead to data corruption when using `glob` or zarr. This PR adds automatic retry in those cases, and should fix the problem with a high likelyhood.