### PR TITLE
use CAR requests when requesting directory listings and file info

### DIFF
--- a/ipfsspec/car.py
+++ b/ipfsspec/car.py
@@ -1,0 +1,116 @@
+"""
+CAR handling functions.
+"""
+
+from typing import List, Optional, Tuple, Union, Iterator, BinaryIO
+import dataclasses
+
+import dag_cbor
+from multiformats import CID, varint, multicodec, multihash
+
+from .utils import is_cid_list, StreamLike, ensure_stream
+
+DagPbCodec = multicodec.get("dag-pb")
+Sha256Hash = multihash.get("sha2-256")
+
+@dataclasses.dataclass
+class CARBlockLocation:
+    varint_size: int
+    cid_size: int
+    payload_size: int
+    offset: int = 0
+
+    @property
+    def cid_offset(self) -> int:
+        return self.offset + self.varint_size
+
+    @property
+    def payload_offset(self) -> int:
+        return self.offset + self.varint_size + self.cid_size
+
+    @property
+    def size(self) -> int:
+        return self.varint_size + self.cid_size + self.payload_size
+
+
+def decode_car_header(stream: BinaryIO) -> Tuple[List[CID], int]:
+    """
+    Decodes a CAR header and returns the list of contained roots.
+    """
+    header_size, visize, _ = varint.decode_raw(stream)  # type: ignore [call-overload] # varint uses BufferedIOBase
+    header = dag_cbor.decode(stream.read(header_size))
+    if not isinstance(header, dict):
+        raise ValueError("no valid CAR header found")
+    if header["version"] != 1:
+        raise ValueError("CAR is not version 1")
+    roots = header["roots"]
+    if not isinstance(roots, list):
+        raise ValueError("CAR header doesn't contain roots")
+    if not is_cid_list(roots):
+        raise ValueError("CAR roots do not only contain CIDs")
+    return roots, visize + header_size
+
+
+def decode_raw_car_block(stream: BinaryIO) -> Optional[Tuple[CID, bytes, CARBlockLocation]]:
+    try:
+        block_size, visize, _ = varint.decode_raw(stream)  # type: ignore [call-overload] # varint uses BufferedIOBase
+    except ValueError:
+        # stream has likely been consumed entirely
+        return None
+
+    data = stream.read(block_size)
+    # as the size of the CID is variable but not explicitly given in
+    # the CAR format, we need to partially decode each CID to determine
+    # its size and the location of the payload data
+    if data[0] == 0x12 and data[1] == 0x20:
+        # this is CIDv0
+        cid_version = 0
+        default_base = "base58btc"
+        cid_codec: Union[int, multicodec.Multicodec] = DagPbCodec
+        hash_codec: Union[int, multihash.Multihash] = Sha256Hash
+        cid_digest = data[2:34]
+        data = data[34:]
+    else:
+        # this is CIDv1(+)
+        cid_version, _, data = varint.decode_raw(data)
+        if cid_version != 1:
+            raise ValueError(f"CIDv{cid_version} is currently not supported")
+        default_base = "base32"
+        cid_codec, _, data = multicodec.unwrap_raw(data)
+        hash_codec, _, data = varint.decode_raw(data)
+        digest_size, _, data = varint.decode_raw(data)
+        cid_digest = data[:digest_size]
+        data = data[digest_size:]
+    cid = CID(default_base, cid_version, cid_codec, (hash_codec, cid_digest))
+
+    if not cid.hashfun.digest(data) == cid.digest:
+        raise ValueError(f"CAR is corrupted. Entry '{cid}' could not be verified")
+
+    return cid, bytes(data), CARBlockLocation(visize, block_size - len(data), len(data))
+
+
+def read_car(stream_or_bytes: StreamLike) -> Tuple[List[CID], Iterator[Tuple[CID, bytes, CARBlockLocation]]]:
+    """
+    Reads a CAR.
+
+    Parameters
+    ----------
+    stream_or_bytes: StreamLike
+        Stream to read CAR from
+
+    Returns
+    -------
+    roots : List[CID]
+        Roots as given by the CAR header
+    blocks : Iterator[Tuple[cid, BytesLike, CARBlockLocation]]
+        Iterator over all blocks contained in the CAR
+    """
+    stream = ensure_stream(stream_or_bytes)
+    roots, header_size = decode_car_header(stream)
+    def blocks() -> Iterator[Tuple[CID, bytes, CARBlockLocation]]:
+        offset = header_size
+        while (next_block := decode_raw_car_block(stream)) is not None:
+            cid, data, sizes = next_block
+            yield cid, data, dataclasses.replace(sizes, offset=offset)
+            offset += sizes.size
+    return roots, blocks()

--- a/ipfsspec/utils.py
+++ b/ipfsspec/utils.py
@@ -1,0 +1,21 @@
+"""
+Some utilities.
+"""
+
+from io import BytesIO
+from typing import List, Union, BinaryIO
+
+from multiformats import CID
+from typing_extensions import TypeGuard
+
+StreamLike = Union[BinaryIO, bytes]
+
+def ensure_stream(stream_or_bytes: StreamLike) -> BinaryIO:
+    if isinstance(stream_or_bytes, bytes):
+        return BytesIO(stream_or_bytes)
+    else:
+        return stream_or_bytes
+
+
+def is_cid_list(os: List[object]) -> TypeGuard[List[CID]]:
+    return all(isinstance(o, CID) for o in os)

--- a/test/test_async.py
+++ b/test/test_async.py
@@ -22,9 +22,10 @@ async def get_client(session):
 
 
 @pytest_asyncio.fixture
-async def fs(get_client):
+async def fs(request, get_client):
     AsyncIPFSFileSystem.clear_instance_cache()  # avoid reusing old event loop
-    return AsyncIPFSFileSystem(asynchronous=True, loop=asyncio.get_running_loop(), get_client=get_client)
+    gateway_addr = getattr(request, "param", None)
+    return AsyncIPFSFileSystem(asynchronous=True, loop=asyncio.get_running_loop(), get_client=get_client, gateway_addr=gateway_addr)
 
 
 @pytest.mark.parametrize("gw_host", ["http://127.0.0.1:8080"])

--- a/test/test_async.py
+++ b/test/test_async.py
@@ -101,3 +101,20 @@ async def test_isfile(fs):
     assert res is True
     res = await fs._isfile(TEST_ROOT)
     assert res is False
+
+@pytest.mark.parametrize("detail", [False, True])
+@pytest.mark.parametrize("fs", ["http://127.0.0.1:8080", "https://ipfs.io"], indirect=True)
+@pytest.mark.asyncio
+async def test_ls_multi_gw(fs, detail):
+    """
+    Test if ls works on different gateway implementations.
+
+    See also: https://github.com/fsspec/ipfsspec/issues/39
+    """
+    res = await fs._ls("bafybeicn7i3soqdgr7dwnrwytgq4zxy7a5jpkizrvhm5mv6bgjd32wm3q4", detail=detail)
+    expected = "bafybeicn7i3soqdgr7dwnrwytgq4zxy7a5jpkizrvhm5mv6bgjd32wm3q4/welcome-to-IPFS.jpg"
+    if detail:
+        assert len(res) == 1
+        assert res[0]["name"] == expected
+    else:
+        assert res == [expected]


### PR DESCRIPTION
As shown in #39, some gateways won't accept `raw` format in requests including a path. This PR uses `car` requests instead and fixes #39.

This fix is still a bit ugly, as it doesn't use the additional blocks in the returned CAR to verify the correctness of the response.