### PR TITLE
Bump required fsspec version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 dynamic = ["version"]
 
 dependencies = [
-    "fsspec>=0.9.0",
+    "fsspec>=2024.12.0",
     "requests",
     "aiohttp",
     "aiohttp-retry",


### PR DESCRIPTION
`ipfsspec` seems to be incompatible with some older versions of `fsspec`. We haven't checked the actual required version, but on my system `fsspec=2024.12.0` does work.